### PR TITLE
Fixes for new platform fastlane and running multiple lanes

### DIFF
--- a/fastlane_env_lanes.gemspec
+++ b/fastlane_env_lanes.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'fastlane_env_lanes'
-  s.version     = '0.1.3'
-  s.date        = '2015-03-10'
+  s.version     = '0.2.0'
+  s.date        = '2015-04-21'
   s.summary     = "Fastlane environment specific lanes"
   s.description = "Fastlane environment specific lanes (implemented a bit hacky)"
   s.authors     = ["Josh Holtz"]
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
     'https://github.com/joshdholtz/fastlane-env-lanes'
   s.license       = 'MIT'
 
-  s.add_dependency 'fastlane', '~> 0.2'
+  s.add_dependency 'fastlane', '~> 0.12'
   s.add_dependency 'dotenv', '~> 0.7'
 end

--- a/lib/fastlane_env_lanes.rb
+++ b/lib/fastlane_env_lanes.rb
@@ -25,7 +25,6 @@ module FastlaneLaneManagerExtensions
 
       keys = key.split(' ') 
       keys.each do |single_key|
-        puts "single_key - #{single_key}"
         args = fl_env_lanes_run_lane(platform, single_key, p_env)
         super(args[0], args[1], args[2])
       end

--- a/lib/fastlane_env_lanes.rb
+++ b/lib/fastlane_env_lanes.rb
@@ -23,6 +23,17 @@ module FastlaneLaneManagerExtensions
 
     def cruise_lane(platform, key, p_env = nil)
 
+      keys = key.split(' ') 
+      keys.each do |single_key|
+        puts "single_key - #{single_key}"
+        args = fl_env_lanes_run_lane(platform, single_key, p_env)
+        super(args[0], args[1], args[2])
+      end
+
+    end
+
+    def fl_env_lanes_run_lane(platform, key, p_env)
+
       env_key = key.to_s.gsub(':', '__')
       lane_key = env_key.split('__')[0]
 
@@ -52,12 +63,12 @@ module FastlaneLaneManagerExtensions
 
       # Checking if the environment lane exists
       if env_key
-        super platform, env_key.to_s, env
+        return platform, env_key.to_s, env
       else
-        super platform, lane_key.to_s, env
+        return platform, lane_key.to_s, env
       end
-
     end
+
   end
 
   def self.prepended(base)


### PR DESCRIPTION
- Fixes for changes in how fastlane runner works
- Can also run multiple lanes but must be in quotes
  - `fastlane "lane1 lane2"`
- Also need to now have a custom action to preload this library properly
  - Create an action file called `envlanes.rb` and use the following code below

``` ruby
require 'bundler/setup'
require 'fastlane_env_lanes'

module Fastlane
  module Actions

    class EnvlanesAction < Action
      def self.run(params)
        Helper.log.info "This should never get run!"
      end
    end
  end
end
```
